### PR TITLE
Simplify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Our mission is to prove the correctness of a selection of the functions in the E
 
 ## Creating Makefile and Building Project
 ```
-$ rocq makefile -f _CoqProject theories/*.v -o Makefile
+$ rocq makefile -f _CoqProject -o Makefile
 $ make
+```
+
+or just
+
+```
+$ ./build.sh
 ```

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,1 +1,2 @@
 -Q theories Temporal
+theories

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-rocq makefile -f _CoqProject theories/*.v -o Makefile
+rocq makefile -f _CoqProject -o Makefile
 make clean
 make

--- a/coq-proj.opam
+++ b/coq-proj.opam
@@ -12,7 +12,7 @@ synopsis: "Formalisation of parts of the TC39 Temporal proposal in Rocq."
 license: "BSD-3-Clause"
 
 build: [
-  ["sh" "-c" "rocq makefile -f _CoqProject theories/*.v -o Makefile"]
+  ["sh" "-c" "rocq makefile -f _CoqProject -o Makefile"]
   [make]
 ]
 


### PR DESCRIPTION
It seems we can just list `theories/` in `_CoqProject`, and `rocq makefile` (as well as other commands) pick up on all our source files. So building the project simplifies to

```
$ rocq makefile -f _CoqProject -o Makefile
$ make
```

which I think is a little nicer.