### PR TITLE
Capitalize ISODateRecord and TimeRecord

### DIFF
--- a/theories/Basic.v
+++ b/theories/Basic.v
@@ -7,6 +7,14 @@ Notation "'assert' P 'in' A" := (let tt := assert P _ in A) (at level 100).
 Notation "'impossible'" := (False_rect _ _).
 Notation "a '!=?' b" := (negb (a =? b)) (at level 70).
 
+Inductive Overflow := CONSTRAIN | REJECT.
+Definition eq (a b : Overflow) : bool := 
+  match a, b with
+  | CONSTRAIN, CONSTRAIN => true
+  | REJECT, REJECT => true
+  | _, _ => false
+  end.
+
 Inductive Unused := UNUSED.
 
 Inductive Exception := RangeError.

--- a/theories/Section3/CompareISODate.v
+++ b/theories/Section3/CompareISODate.v
@@ -5,19 +5,19 @@ From Temporal Require Import
 Open Scope Z.
 
 (* 3.5.12 CompareISODate *)
-Definition CompareISODate (isoDate1 isoDate2 : ISODateRecord) : Z :=
+Definition CompareISODate (isoDate1 : ISODateRecord) (isoDate2 : ISODateRecord) : Z :=
   (*>> 1. If isoDate1.[[Year]] > isoDate2.[[Year]], return 1. <<*)
-  if (year isoDate1) >? (year isoDate2) then 1
+  if (Year isoDate1) >? (Year isoDate2) then 1
   (*>> 2. If isoDate1.[[Year]] < isoDate2.[[Year]], return -1. <<*)
-  else if (year isoDate1) <? (year isoDate2) then -1
+  else if (Year isoDate1) <? (Year isoDate2) then -1
   (*>> 3. If isoDate1.[[Month]] > isoDate2.[[Month]], return 1. <<*)
-  else if (month isoDate1) >? (month isoDate2) then 1
+  else if (Month isoDate1) >? (Month isoDate2) then 1
   (*>> 4. If isoDate1.[[Month]] < isoDate2.[[Month]], return -1. <<*)
-  else if (month isoDate1) <? (month isoDate2) then -1
+  else if (Month isoDate1) <? (Month isoDate2) then -1
   (*>> 5. If isoDate1.[[Day]] > isoDate2.[[Day]], return 1. <<*)
-  else if (day isoDate1) >? (day isoDate2) then 1
+  else if (Day isoDate1) >? (Day isoDate2) then 1
   (*>> 6. If isoDate1.[[Day]] < isoDate2.[[Day]], return -1. <<*)
-  else if (day isoDate1) <? (day isoDate2) then -1
+  else if (Day isoDate1) <? (Day isoDate2) then -1
   (*>> 7. Return 0. <<*)
   else 0.
 

--- a/theories/Section3/ISODateRecord.v
+++ b/theories/Section3/ISODateRecord.v
@@ -7,13 +7,13 @@ Record ISODateRecord : Type :=
   mkISODateRecord {
     (*>> Field Name | Value                                 | Meaning <<*)
     (*>> [[Year]]  | an integer                             | The year in the ISO 8601 calendar. <<*)
-    year : Z;
+    Year : Z;
     (*>> [[Month]] | an integer between 1 and 12, inclusive | The number of the month in the ISO 8601 calendar. <<*)
-    month : Z;
+    Month : Z;
     (*>> [[Day]]   | an integer between 1 and 31, inclusive | The number of the day of the month in the ISO 8601 calendar. <<*)
-    day : Z;
+    Day : Z;
 
-    month_valid : 1 <= month <= 12;
-    day_valid : 1 <= day <= 31;
-    is_valid_ISO_date: IsValidISODate year month day = true;
+    month_valid : 1 <= Month <= 12;
+    day_valid : 1 <= Day <= 31;
+    is_valid_ISO_date: IsValidISODate Year Month Day = true;
   }.

--- a/theories/Section3/RegulateISODate.v
+++ b/theories/Section3/RegulateISODate.v
@@ -10,14 +10,6 @@ From Temporal Require Import
   StringUtil.
 Open Scope Z.
 
-Inductive Overflow := CONSTRAIN | REJECT.
-Definition eq (a b : Overflow) : bool := 
-  match a, b with
-  | CONSTRAIN, CONSTRAIN => true
-  | REJECT, REJECT => true
-  | _, _ => false
-  end.
-
 (* 3.5.6 RegulateISODate *)
 Program Definition RegulateISODate (year month day : Z) (overflow : Overflow) : Completion ISODateRecord :=
   match overflow with

--- a/theories/Section3/TemporalDateToString.v
+++ b/theories/Section3/TemporalDateToString.v
@@ -13,11 +13,11 @@ Open Scope Z.
 (* 3.5.10 TemporalDateToString *)
 Program Definition TemporalDateToString (temporalDate : PlainDate) (showCalendar : ShowCalendar) : string :=
   (*>> 1. Let year be PadISOYear(temporalDate.[[ISODate]].[[Year]]). <<*)
-  let year := PadISOYear (year (isoDate temporalDate)) in
+  let year := PadISOYear (Year (isoDate temporalDate)) in
   (*>> 2. Let month be ToZeroPaddedDecimalString(temporalDate.[[ISODate]].[[Month]], 2). <<*)
-  let month := ToZeroPaddedDecimalString (month (isoDate temporalDate)) 2 _ _ in
+  let month := ToZeroPaddedDecimalString (Month (isoDate temporalDate)) 2 _ _ in
   (*>> 3. Let day be ToZeroPaddedDecimalString(temporalDate.[[ISODate]].[[Day]], 2). <<*)
-  let day := ToZeroPaddedDecimalString (day (isoDate temporalDate)) 2 _ _ in
+  let day := ToZeroPaddedDecimalString (Day (isoDate temporalDate)) 2 _ _ in
   (*>> 4. Let calendar be FormatCalendarAnnotation(temporalDate.[[Calendar]], showCalendar). <<*)
   let calendar := FormatCalendarAnnotation (calendar temporalDate) showCalendar in
   (*>> 5. Return the string-concatenation of year, the code unit 0x002D (HYPHEN-MINUS), month, the code unit 0x002D (HYPHEN-MINUS), day, and calendar. <<*)
@@ -38,7 +38,7 @@ Next Obligation.
 Qed.
 
 Theorem TemporalDateToString_without_calendar_satisfies_rfc3339 :
-  forall temporalDate, 0 <= year (PlainDate.isoDate temporalDate) <= 9999 ->
+  forall temporalDate, 0 <= Year (PlainDate.isoDate temporalDate) <= 9999 ->
   generates RFC3339.full_date (TemporalDateToString temporalDate SC_NEVER).
 Proof.
   intros.

--- a/theories/Section4/AddTime.v
+++ b/theories/Section4/AddTime.v
@@ -8,7 +8,7 @@ From Temporal Require Import
 (* 4.5.15 AddTime *)
 Definition AddTime (time : TimeRecord) (timeDuration : Z) (timeDuration_valid : MinTimeDuration <= timeDuration <= MaxTimeDuration) : TimeRecord :=
   (*>> 1. Return BalanceTime(time.[[Hour]], time.[[Minute]], time.[[Second]], time.[[Millisecond]], time.[[Microsecond]], time.[[Nanosecond]] + timeDuration). <<*)
-  BalanceTime (hour time) (minute time) (second time) (millisecond time) (microsecond time) (nanosecond time + timeDuration).
+  BalanceTime (Hour time) (Minute time) (Second time) (Millisecond time) (Microsecond time) (Nanosecond time + timeDuration).
   (*>> 2. NOTE: If using floating points to implement this operation, add the time components separately before balancing to avoid errors with unsafe integers. <<*)
 
 Lemma zero_timeDuration_valid : MinTimeDuration <= 0 <= MaxTimeDuration.
@@ -19,48 +19,48 @@ Qed.
 Theorem AddTime_adding_zero_no_change :
   forall time,
   let time' := AddTime time 0 zero_timeDuration_valid in
-     days time' = 0
-  /\ minute time = minute time'
-  /\ second time = second time'
-  /\ millisecond time = millisecond time'
-  /\ microsecond time = microsecond time'
-  /\ nanosecond time = nanosecond time'.
+     Days time' = 0
+  /\ Minute time = Minute time'
+  /\ Second time = Second time'
+  /\ Millisecond time = Millisecond time'
+  /\ Microsecond time = Microsecond time'
+  /\ Nanosecond time = Nanosecond time'.
 Proof.
   intros.
   repeat split.
   - simpl.
-    rewrite add_div_small with (a := (nanosecond time + 0)).
+    rewrite add_div_small with (a := (Nanosecond time + 0)).
     all: try rewrite Z.add_0_r.
-    rewrite add_div_small with (a := microsecond time).
-    rewrite add_div_small with (a := millisecond time).
-    rewrite add_div_small with (a := second time).
-    rewrite add_div_small with (a := minute time).
+    rewrite add_div_small with (a := Microsecond time).
+    rewrite add_div_small with (a := Millisecond time).
+    rewrite add_div_small with (a := Second time).
+    rewrite add_div_small with (a := Minute time).
     rewrite div_small_pred.
     all: now destruct time.
   - simpl.
-    rewrite add_div_small with (a := (nanosecond time + 0)).
+    rewrite add_div_small with (a := (Nanosecond time + 0)).
     all: try rewrite Z.add_0_r.
-    rewrite add_div_small with (a := microsecond time).
-    rewrite add_div_small with (a := millisecond time).
-    rewrite add_div_small with (a := second time).
+    rewrite add_div_small with (a := Microsecond time).
+    rewrite add_div_small with (a := Millisecond time).
+    rewrite add_div_small with (a := Second time).
     rewrite mod_small_pred.
     all: now destruct time.
   - simpl.
-    rewrite add_div_small with (a := (nanosecond time + 0)).
+    rewrite add_div_small with (a := (Nanosecond time + 0)).
     all: try rewrite Z.add_0_r.
-    rewrite add_div_small with (a := microsecond time).
-    rewrite add_div_small with (a := millisecond time).
+    rewrite add_div_small with (a := Microsecond time).
+    rewrite add_div_small with (a := Millisecond time).
     rewrite mod_small_pred.
     all: now destruct time.
   - simpl.
-    rewrite add_div_small with (a := (nanosecond time + 0)).
+    rewrite add_div_small with (a := (Nanosecond time + 0)).
     all: try rewrite Z.add_0_r.
-    rewrite add_div_small with (a := microsecond time).
+    rewrite add_div_small with (a := Microsecond time).
     rewrite mod_small_pred.
     all: now destruct time.
   - simpl.
     rewrite Z.add_0_r.
-    rewrite add_div_small with (a := nanosecond time).
+    rewrite add_div_small with (a := Nanosecond time).
     rewrite mod_small_pred.
     all: now destruct time.
   - simpl.

--- a/theories/Section4/BalanceTime.v
+++ b/theories/Section4/BalanceTime.v
@@ -80,7 +80,7 @@ Qed.
 Theorem BalanceTime_IsValidTime :
   forall h min s ms us ns,
   let t := BalanceTime h min s ms us ns in
-  IsValidTime (hour t) (minute t) (second t) (millisecond t) (microsecond t) (nanosecond t) = true.
+  IsValidTime (Hour t) (Minute t) (Second t) (Millisecond t) (Microsecond t) (Nanosecond t) = true.
 Proof.
   intros.
   unfold IsValidTime.
@@ -90,7 +90,7 @@ Qed.
 Theorem BalanceTime_days_valid_when_nonnegative_inputs :
   forall h min s ms us ns,
   0 <= h -> 0 <= min -> 0 <= s -> 0 <= ms -> 0 <= us -> 0 <= ns ->
-  0 <= days (BalanceTime h min s ms us ns).
+  0 <= Days (BalanceTime h min s ms us ns).
 Proof.
   intros.
   unfold BalanceTime.

--- a/theories/Section4/CompareTimeRecord.v
+++ b/theories/Section4/CompareTimeRecord.v
@@ -5,29 +5,29 @@ Open Scope Z.
 (* 4.5.14 CompareTimeRecord *)
 Definition CompareTimeRecord (time1 time2 : TimeRecord) : Z :=
   (*>> 1. If time1.[[Hour]] > time2.[[Hour]], return 1. <<*)
-  if hour time1 >? hour time2 then 1
+  if Hour time1 >? Hour time2 then 1
   (*>> 2. If time1.[[Hour]] < time2.[[Hour]], return -1. <<*)
-  else if hour time1 <? hour time2 then -1
+  else if Hour time1 <? Hour time2 then -1
   (*>> 3. If time1.[[Minute]] > time2.[[Minute]], return 1. <<*)
-  else if minute time1 >? minute time2 then 1
+  else if Minute time1 >? Minute time2 then 1
   (*>> 4. If time1.[[Minute]] < time2.[[Minute]], return -1. <<*)
-  else if minute time1 <? minute time2 then -1
+  else if Minute time1 <? Minute time2 then -1
   (*>> 5. If time1.[[Second]] > time2.[[Second]], return 1. <<*)
-  else if second time1 >? second time2 then 1
+  else if Second time1 >? Second time2 then 1
   (*>> 6. If time1.[[Second]] < time2.[[Second]], return -1. <<*)
-  else if second time1 <? second time2 then -1
+  else if Second time1 <? Second time2 then -1
   (*>> 7. If time1.[[Millisecond]] > time2.[[Millisecond]], return 1. <<*)
-  else if millisecond time1 >? millisecond time2 then 1
+  else if Millisecond time1 >? Millisecond time2 then 1
   (*>> 8. If time1.[[Millisecond]] < time2.[[Millisecond]], return -1. <<*)
-  else if millisecond time1 <? millisecond time2 then -1
+  else if Millisecond time1 <? Millisecond time2 then -1
   (*>> 9. If time1.[[Microsecond]] > time2.[[Microsecond]], return 1. <<*)
-  else if microsecond time1 >? microsecond time2 then 1
+  else if Microsecond time1 >? Microsecond time2 then 1
   (*>> 10. If time1.[[Microsecond]] < time2.[[Microsecond]], return -1. <<*)
-  else if microsecond time1 <? microsecond time2 then -1
+  else if Microsecond time1 <? Microsecond time2 then -1
   (*>> 11. If time1.[[Nanosecond]] > time2.[[Nanosecond]], return 1. <<*)
-  else if nanosecond time1 >? nanosecond time2 then 1
+  else if Nanosecond time1 >? Nanosecond time2 then 1
   (*>> 12. If time1.[[Nanosecond]] < time2.[[Nanosecond]], return -1. <<*)
-  else if nanosecond time1 <? nanosecond time2 then -1
+  else if Nanosecond time1 <? Nanosecond time2 then -1
   (*>> 13. Return 0. <<*)
   else 0.
 

--- a/theories/Section4/DifferenceTime.v
+++ b/theories/Section4/DifferenceTime.v
@@ -11,17 +11,17 @@ Open Scope Z.
 (* 4.5.5 DifferenceTime *)
 Program Definition DifferenceTime (time1 time2 : TimeRecord) : Z :=
   (*>> 1. Let hours be time2.[[Hour]] - time1.[[Hour]]. <<*)
-  let hours := (hour time2) - (hour time1) in
+  let hours := (Hour time2) - (Hour time1) in
   (*>> 2. Let minutes be time2.[[Minute]] - time1.[[Minute]]. <<*)
-  let minutes := (minute time2) - (minute time1) in
+  let minutes := (Minute time2) - (Minute time1) in
   (*>> 3. Let seconds be time2.[[Second]] - time1.[[Second]]. <<*)
-  let seconds := (second time2) - (second time1) in
+  let seconds := (Second time2) - (Second time1) in
   (*>> 4. Let milliseconds be time2.[[Millisecond]] - time1.[[Millisecond]]. <<*)
-  let milliseconds := (millisecond time2) - (millisecond time1) in
+  let milliseconds := (Millisecond time2) - (Millisecond time1) in
   (*>> 5. Let microseconds be time2.[[Microsecond]] - time1.[[Microsecond]]. <<*)
-  let microseconds := (microsecond time2) - (microsecond time1) in
+  let microseconds := (Microsecond time2) - (Microsecond time1) in
   (*>> 6. Let nanoseconds be time2.[[Nanosecond]] - time1.[[Nanosecond]]. <<*)
-  let nanoseconds := (nanosecond time2) - (nanosecond time1) in
+  let nanoseconds := (Nanosecond time2) - (Nanosecond time1) in
   (*>> 7. Let timeDuration be TimeDurationFromComponents(hours, minutes, seconds, milliseconds, microseconds, nanoseconds). <<*)
   let timeDuration := TimeDurationFromComponents hours minutes seconds milliseconds microseconds nanoseconds in
   (*>> 8. Assert: abs(timeDuration) < nsPerDay. <<*)

--- a/theories/Section4/RegulateTime.v
+++ b/theories/Section4/RegulateTime.v
@@ -8,8 +8,6 @@ From Temporal Require Import
   Section4.TimeRecord.
 Open Scope Z.
 
-Inductive Overflow := CONSTRAIN | REJECT.
-
 (* 4.5.8 RegulateTime *)
 Program Definition RegulateTime (hour minute second millisecond microsecond nanosecond : Z) 
   (overflow : Overflow) : Completion TimeRecord :=

--- a/theories/Section4/TimeRecord.v
+++ b/theories/Section4/TimeRecord.v
@@ -11,41 +11,41 @@ Record TimeRecord :=
   mkTimeRecord {
     (*>> Field Name      | Value                                              | Meaning <<*)
     (*>> [[Days]]        | an integer                                         | A number of overflow days. <<*)
-    days : Z;
+    Days : Z;
     (*>> [[Hour]]        | an integer in the inclusive interval from 0 to 23  | The number of the hour. <<*)
-    hour : Z;
+    Hour : Z;
     (*>> [[Minute]]      | an integer in the inclusive interval from 0 to 59  | The number of the minute. <<*)
-    minute : Z;
+    Minute : Z;
     (*>> [[Second]]      | an integer in the inclusive interval from 0 to 59  | The number of the second. <<*)
-    second : Z;
+    Second : Z;
     (*>> [[Millisecond]] | an integer in the inclusive interval from 0 to 999 | The number of the millisecond. <<*)
-    millisecond : Z;
+    Millisecond : Z;
     (*>> [[Microsecond]] | an integer in the inclusive interval from 0 to 999 | The number of the microsecond. <<*)
-    microsecond : Z;
+    Microsecond : Z;
     (*>> [[Nanosecond]]  | an integer in the inclusive interval from 0 to 999 | The number of the nanosecond. <<*)
-    nanosecond : Z;
+    Nanosecond : Z;
 
-    hour_valid : 0 <= hour <= 23;
-    minute_valid : 0 <= minute <= 59;
-    second_valid : 0 <= second <= 59;
-    millisecond_valid : 0 <= millisecond <= 999;
-    microsecond_valid : 0 <= microsecond <= 999;
-    nanosecond_valid : 0 <= nanosecond <= 999;
+    hour_valid : 0 <= Hour <= 23;
+    minute_valid : 0 <= Minute <= 59;
+    second_valid : 0 <= Second <= 59;
+    millisecond_valid : 0 <= Millisecond <= 999;
+    microsecond_valid : 0 <= Microsecond <= 999;
+    nanosecond_valid : 0 <= Nanosecond <= 999;
   }.
 
 Lemma TimeRecord_IsValidTime :
   forall (t : TimeRecord),
-  IsValidTime (hour t) (minute t) (second t) (millisecond t) (microsecond t) (nanosecond t) = true.
+  IsValidTime (Hour t) (Minute t) (Second t) (Millisecond t) (Microsecond t) (Nanosecond t) = true.
 Proof.
   intro t.
   destruct t.
   simpl.
   unfold IsValidTime.
 
-  destruct_with_eqn ((hour0 <? 0) || (hour0 >? 23)); try lia.
-  destruct_with_eqn ((minute0 <? 0) || (minute0 >? 59)); try lia.
-  destruct_with_eqn ((second0 <? 0) || (second0 >? 59)); try lia.
-  destruct_with_eqn ((millisecond0 <? 0) || (millisecond0 >? 999)); try lia.
-  destruct_with_eqn ((microsecond0 <? 0) || (microsecond0 >? 999)); try lia.
-  destruct_with_eqn ((nanosecond0 <? 0) || (nanosecond0 >? 999)); try lia.
+  destruct_with_eqn ((Hour0 <? 0) || (Hour0 >? 23)); try lia.
+  destruct_with_eqn ((Minute0 <? 0) || (Minute0 >? 59)); try lia.
+  destruct_with_eqn ((Second0 <? 0) || (Second0 >? 59)); try lia.
+  destruct_with_eqn ((Millisecond0 <? 0) || (Millisecond0 >? 999)); try lia.
+  destruct_with_eqn ((Microsecond0 <? 0) || (Microsecond0 >? 999)); try lia.
+  destruct_with_eqn ((Nanosecond0 <? 0) || (Nanosecond0 >? 999)); try lia.
 Qed.

--- a/theories/Section4/TimeRecordToString.v
+++ b/theories/Section4/TimeRecordToString.v
@@ -11,9 +11,9 @@ Open Scope Z.
 (* 4.5.13 TimeRecordToString *)
 Program Definition TimeRecordToString (time : TimeRecord) (precision : Precision') : string :=
   (*>> 1. Let subSecondNanoseconds be time.[[Millisecond]] × 10**6 + time.[[Microsecond]] × 10**3 + time.[[Nanosecond]]. <<*)
-  let subSecondNanoseconds := (millisecond time) * 1000000 + (microsecond time) * 1000 + (nanosecond time) in 
+  let subSecondNanoseconds := (Millisecond time) * 1000000 + (Microsecond time) * 1000 + (Nanosecond time) in 
   (*>> 2. Return FormatTimeString(time.[[Hour]], time.[[Minute]], time.[[Second]], subSecondNanoseconds, precision). <<*)
-  FormatTimeString (hour time) (minute time) (second time) subSecondNanoseconds precision None (hour_valid time) (minute_valid time) (second_valid time) _.
+  FormatTimeString (Hour time) (Minute time) (Second time) subSecondNanoseconds precision None (hour_valid time) (minute_valid time) (second_valid time) _.
 
 Next Obligation.
   split.

--- a/theories/Section5/ISODateTimeRecord.v
+++ b/theories/Section5/ISODateTimeRecord.v
@@ -19,6 +19,6 @@ mkISODateTimeRecord {
   (*>> [[Time]]    | a Time Record      | The time. The [[Days]] field is ignored. <<*)
   Time : TimeRecord;
 
-  ISODate_valid : IsValidISODate (year ISODate) (month ISODate) (day ISODate) = true;
-  Time_valid : IsValidTime (hour Time) (minute Time) (second Time) (millisecond Time) (microsecond Time) (nanosecond Time) = true;
+  ISODate_valid : IsValidISODate (Year ISODate) (Month ISODate) (Day ISODate) = true;
+  Time_valid : IsValidTime (Hour Time) (Minute Time) (Second Time) (Millisecond Time) (Microsecond Time) (Nanosecond Time) = true;
   }.

--- a/theories/Section5/ISODateTimeToString.v
+++ b/theories/Section5/ISODateTimeToString.v
@@ -22,15 +22,15 @@ Open Scope Z.
 (* 5.5.9 ISODateTimeToString *)
 Program Definition ISODateTimeToString (isoDateTime : ISODateTimeRecord) (calendar : CalendarType) (precision' : Precision') (showCalendar : ShowCalendar) :=
 (*>> 1. Let yearString be PadISOYear(isoDateTime.[[ISODate]].[[Year]]). <<*)
-  let yearString := PadISOYear (year (ISODate isoDateTime)) in
+  let yearString := PadISOYear (Year (ISODate isoDateTime)) in
   (*>> 2. Let monthString be ToZeroPaddedDecimalString(isoDateTime.[[ISODate]].[[Month]], 2). <<*)
-  let monthString := ToZeroPaddedDecimalString (month (ISODate isoDateTime)) 2 _ zero_le_two in
+  let monthString := ToZeroPaddedDecimalString (Month (ISODate isoDateTime)) 2 _ zero_le_two in
   (*>> 3. Let dayString be ToZeroPaddedDecimalString(isoDateTime.[[ISODate]].[[Day]], 2). <<*)
-  let dayString := ToZeroPaddedDecimalString (day (ISODate isoDateTime)) 2 _ zero_le_two in
+  let dayString := ToZeroPaddedDecimalString (Day (ISODate isoDateTime)) 2 _ zero_le_two in
   (*>> 4. Let subSecondNanoseconds be isoDateTime.[[Time]].[[Millisecond]] × 10**6 + isoDateTime.[[Time]].[[Microsecond]] × 10**3 + isoDateTime.[[Time]].[[Nanosecond]]. <<*)
-  let subSecondNanoseconds := (millisecond (Time isoDateTime)) * 1000000 + (microsecond (Time isoDateTime)) * 1000 + (nanosecond (Time isoDateTime)) in 
+  let subSecondNanoseconds := (Millisecond (Time isoDateTime)) * 1000000 + (Microsecond (Time isoDateTime)) * 1000 + (Nanosecond (Time isoDateTime)) in 
   (*>> 5. Let timeString be FormatTimeString(isoDateTime.[[Time]].[[Hour]], isoDateTime.[[Time]].[[Minute]], isoDateTime.[[Time]].[[Second]], subSecondNanoseconds, precision). <<*)
-  let timeString := FormatTimeString (hour (Time isoDateTime)) (minute (Time isoDateTime)) (second (Time isoDateTime)) subSecondNanoseconds precision' None _ _ _ _ in
+  let timeString := FormatTimeString (Hour (Time isoDateTime)) (Minute (Time isoDateTime)) (Second (Time isoDateTime)) subSecondNanoseconds precision' None _ _ _ _ in
   (*>> 6. Let calendarString be FormatCalendarAnnotation(calendar, showCalendar). <<*)
   let calendarString := FormatCalendarAnnotation calendar showCalendar in
   (*>> 7. Return the string-concatenation of yearString, the code unit 0x002D (HYPHEN-MINUS), monthString, the code unit 0x002D (HYPHEN-MINUS), dayString, 0x0054 (LATIN CAPITAL LETTER T), timeString, and calendarString. <<*)
@@ -45,7 +45,7 @@ Next Obligation. destruct isoDateTime. destruct Time. simpl. lia. Qed.
 
 Lemma month_rfc3339 :
   forall isoDate h,
-  generates RFC3339.date_month (ToZeroPaddedDecimalString (month isoDate) 2 h zero_le_two).
+  generates RFC3339.date_month (ToZeroPaddedDecimalString (Month isoDate) 2 h zero_le_two).
 Proof.
   intros.
   apply ToZeroPaddedDecimalString_2_digits.
@@ -59,7 +59,7 @@ Qed.
 
 Lemma mday_rfc3339 :
   forall isoDate h,
-  generates RFC3339.date_mday (ToZeroPaddedDecimalString (day isoDate) 2 h zero_le_two).
+  generates RFC3339.date_mday (ToZeroPaddedDecimalString (Day isoDate) 2 h zero_le_two).
 Proof.
   intros.
   apply ToZeroPaddedDecimalString_2_digits.
@@ -73,7 +73,7 @@ Qed.
 
 Theorem ISODateTimeToString_without_calendar_satisfies_rfc3339 :
   forall isoDateTime calendar precision,
-  0 <= year (ISODate isoDateTime) <= 9999 ->
+  0 <= Year (ISODate isoDateTime) <= 9999 ->
   generates RFC3339.date_time_without_offset (ISODateTimeToString isoDateTime calendar (NormalPrecision precision) SC_NEVER).
 Proof.
   intros.

--- a/theories/Section9/ISOYearMonthWithinLimits.v
+++ b/theories/Section9/ISOYearMonthWithinLimits.v
@@ -6,15 +6,15 @@ Open Scope Z.
 (* 9.5.3 ISOYearMonthWithinLimits *)
 Definition ISOYearMonthWithinLimits (isoDate : ISODateRecord) : bool :=
   (*>> 1. If isoDate.[[Year]] < -271821 or isoDate.[[Year]] > 275760, then <<*)
-  if (year isoDate <? -271821) || (year isoDate >? 275760)
+  if (Year isoDate <? -271821) || (Year isoDate >? 275760)
     (*>> a. Return false. <<*)
     then false
   (*>> 2. If isoDate.[[Year]] = -271821 and isoDate.[[Month]] < 4, then <<*)
-  else if (year isoDate =? -271821) && (month isoDate <? 4)
+  else if (Year isoDate =? -271821) && (Month isoDate <? 4)
     (*>> a. Return false. <<*)
     then false
   (*>> 3. If isoDate.[[Year]] = 275760 and isoDate.[[Month]] > 9, then <<*)
-  else if (year isoDate =? 275760) && (month isoDate >? 9)
+  else if (Year isoDate =? 275760) && (Month isoDate >? 9)
     (*>> a. Return false. <<*)
     then false
   (*>> 4. Return true. <<*)


### PR DESCRIPTION
To make it more similar to the functions in the spec

Also moves Overflow into Basic instead of having a duplicate type in two different files